### PR TITLE
Round value of water pressure

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -311,7 +311,7 @@ def processResponse(self, data):
             if "otFbFlameOn" in boiler and boiler["otFbFlameOn"] is not None:
                 updateDevice(self, 18, '', int(boiler["otFbFlameOn"]))
             if "otFbWaterPressure" in boiler and boiler["otFbWaterPressure"] is not None:
-                updateDevice(self, 34, '', int(boiler["otFbWaterPressure"]))
+                updateDevice(self, 34, round(boiler["otFbWaterPressure"], 2), 1)
         
         # Process QC data
         if "qc" in data:


### PR DESCRIPTION
I sent the wrong change set, the pressure was truncated instead of rounded. This is fixed now.

## Summary by Sourcery

Bug Fixes:
- Round water pressure to two decimal places instead of truncating